### PR TITLE
feat/previous_translate #125

### DIFF
--- a/app/src/main/java/com/data/app/data/response_dto/home/ai/ResponseAIPreviousChatMessagesDto.kt
+++ b/app/src/main/java/com/data/app/data/response_dto/home/ai/ResponseAIPreviousChatMessagesDto.kt
@@ -13,7 +13,7 @@ data class ResponseAIPreviousChatMessagesDto (
         @SerialName("messageId")
         val messageId:Int,
         @SerialName("text")
-        val text:String,
+        var text:String,
         @SerialName("isUser")
         val isUser:Boolean,
         @SerialName("storedAt")

--- a/app/src/main/java/com/data/app/presentation/main/home/ai_practice/ai_chat/AIChatAdapter.kt
+++ b/app/src/main/java/com/data/app/presentation/main/home/ai_practice/ai_chat/AIChatAdapter.kt
@@ -38,6 +38,9 @@ class AIChatAdapter(
 
     private val chatList = mutableListOf<ResponseChatAiMessageDto.Message>()
 
+    private val originalTextMap: MutableMap<Int, String> = mutableMapOf()
+    private val longPressCheck = mutableListOf<Int>()
+
     private var blinkingJob: Job? = null
 
 
@@ -96,14 +99,8 @@ class AIChatAdapter(
 
             setCustomTouchListener(
                 targetView = binding.tvChat,
-                onLongPress = {
-                    change(pos)
-                    request(content.messageId)},
-
-                onLongPressEnd = {
-                    Log.d("MYCHAT", chatList.toString())
-                    chatList[pos].text = originalText.toString()
-                    notifyItemChanged(pos)},
+                onLongPress = {},
+                onLongPressEnd = {},
                 onClick = {clickChat(content.text)}
             )
             //binding.tvChat.setOnClickListener{clickChat(content.text)}
@@ -151,23 +148,32 @@ class AIChatAdapter(
                 layoutParams.topMargin = if (isFirstOfType) 0 else dpToPx(8)
                 tvChat.layoutParams = layoutParams
 
-                val originalText = binding.tvChat.text
+                if (content.messageId !in longPressCheck){
+                    originalTextMap[content.messageId] = binding.tvChat.text.toString()
+                }
+
                 val pos = bindingAdapterPosition
 
                 setCustomTouchListener(
                     targetView = binding.tvChat,
                     onLongPress = {
                         Timber.d("ai chat long pressing~")
-                        change(pos)
-                        request(content.messageId)
-                        binding.ivLoad1.visibility = View.GONE
-                        binding.ivLoad2.visibility = View.GONE
+                        if (content.messageId !in longPressCheck){
+                            longPressCheck.add(content.messageId)
+                            change(pos)
+                            request(content.messageId)
+                            binding.ivLoad1.visibility = View.GONE
+                            binding.ivLoad2.visibility = View.GONE
+                        }
+
                     },
                     onLongPressEnd = {
                         Log.d("AICHAT", chatList.toString())
-                        chatList[pos].text = originalText.toString()
-                        notifyItemChanged(pos)},
-                    onClick = {clickChat(content.text)}
+                        longPressCheck.remove(content.messageId)
+                        chatList[pos].text = originalTextMap[content.messageId].toString()
+                        notifyItemChanged(pos)
+                    },
+                    onClick = {clickChat(originalTextMap[content.messageId].toString())}
                 )
                 //binding.tvChat.setOnClickListener{clickChat(content.text)}
             }


### PR DESCRIPTION
related issue : #125 

- 이전 대화 내역의 채팅 꾹 누르면 번역되게 완료
- AI대화창 / 이전 대화 내역 창 : 번역된 상태에서 누를 시, 한국어 읽어주게 & 꾹 누른 상태 (번역된 상태) 에선 다시 꾹 못누르게 반영
- 이전 대화 내역 창 리사이클러뷰 접으면 tts 중단하게 수정