### PR TITLE
fix/image-and-time #134 #135

### DIFF
--- a/app/src/main/java/com/data/app/presentation/main/community/PostsAdapter.kt
+++ b/app/src/main/java/com/data/app/presentation/main/community/PostsAdapter.kt
@@ -28,6 +28,7 @@ class PostsAdapter(
         private const val VIEW_TYPE_SHIMMER = 0
         private const val VIEW_TYPE_NORMAL = 1
     }
+
     private var postsList = mutableListOf<ResponseTimeLineDto.TimelinePostItem>()
     private var isLoading = true
 
@@ -37,7 +38,8 @@ class PostsAdapter(
                 .inflate(R.layout.item_post_shimmer, parent, false)
             ShimmerViewHolder(view)
         } else {
-            val binding = ItemPostBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            val binding =
+                ItemPostBinding.inflate(LayoutInflater.from(parent.context), parent, false)
             FeedsViewHolder(binding)
         }
     }
@@ -47,7 +49,7 @@ class PostsAdapter(
         notifyDataSetChanged()
     }
 
-    override fun getItemCount(): Int =if (isLoading) 5 else postsList.size
+    override fun getItemCount(): Int = if (isLoading) 5 else postsList.size
 
     override fun getItemViewType(position: Int): Int {
         return if (isLoading) VIEW_TYPE_SHIMMER else VIEW_TYPE_NORMAL
@@ -75,8 +77,7 @@ class PostsAdapter(
         RecyclerView.ViewHolder(binding.root) {
         fun bind(data: ResponseTimeLineDto.TimelinePostItem) {
             with(binding) {
-                val profile =
-                    data.authorProfile.profileImage?.let { BuildConfig.BASE_URL.removeSuffix("/") + it }
+                val profile = data.authorProfile.profileImage
                 ivProfile.load(profile) {
                     transformations(CircleCropTransformation())
                     placeholder(R.drawable.ic_profile)
@@ -88,8 +89,7 @@ class PostsAdapter(
                 if (!data.post.imageUrl.isNullOrEmpty()) {
                     ivImage.visibility = View.VISIBLE
 
-                    val imageUrl =
-                        data.post.imageUrl?.let { BuildConfig.BASE_URL.removeSuffix("/") + it }
+                    val imageUrl = data.post.imageUrl
                     Timber.d("imageUrl: $imageUrl")
 
                     ivImage.load(imageUrl) {

--- a/app/src/main/java/com/data/app/presentation/main/community/other/OtherProfileAdapter.kt
+++ b/app/src/main/java/com/data/app/presentation/main/community/other/OtherProfileAdapter.kt
@@ -46,7 +46,7 @@ RecyclerView.Adapter<OtherProfileAdapter.OtherProfileViewHolder>(){
         fun bind(data: ResponseTimeLineDto.TimelinePostItem) {
             with(binding) {
                 val profile =
-                    data.authorProfile.profileImage?.let { BuildConfig.BASE_URL.removeSuffix("/") + it }
+                    data.authorProfile.profileImage
                 Timber.d("profile is $profile")
                 binding.ivProfile.load(profile){
                     transformations(CircleCropTransformation())
@@ -59,7 +59,7 @@ RecyclerView.Adapter<OtherProfileAdapter.OtherProfileViewHolder>(){
                 val post = data.post
                 Timber.d("imageUrl: ${post.imageUrl}")
                 if (!post.imageUrl.isNullOrEmpty()) {
-                    val imageUrl = post.imageUrl.let { BuildConfig.BASE_URL.removeSuffix("/") + it }
+                    val imageUrl = post.imageUrl
                     binding.ivImage.visibility = View.VISIBLE
                     binding.ivImage.load(imageUrl) {
                         transformations(RoundedCornersTransformation(30f))

--- a/app/src/main/java/com/data/app/presentation/main/community/other/OtherProfileFragment.kt
+++ b/app/src/main/java/com/data/app/presentation/main/community/other/OtherProfileFragment.kt
@@ -105,11 +105,7 @@ class OtherProfileFragment : Fragment() {
                         Timber.d("userProfileState is success")
                         with(binding) {
                             val profile =
-                                userProfileState.response.profileImage?.let {
-                                    BuildConfig.BASE_URL.removeSuffix(
-                                        "/"
-                                    ) + it
-                                }
+                                userProfileState.response.profileImage
                             ivProfile.load(profile) {
                                 transformations(CircleCropTransformation())
                                 placeholder(R.drawable.ic_profile)

--- a/app/src/main/java/com/data/app/presentation/main/community/post_detail/PostDetailAdapter.kt
+++ b/app/src/main/java/com/data/app/presentation/main/community/post_detail/PostDetailAdapter.kt
@@ -12,6 +12,7 @@ import com.data.app.R
 import com.data.app.data.response_dto.community.ResponsePostDetailDto
 import com.data.app.databinding.ItemCommentBinding
 import com.data.app.databinding.ItemCommentWriteBinding
+import com.data.app.util.TimeAgoFormatter
 import timber.log.Timber
 
 class PostDetailAdapter(
@@ -74,9 +75,7 @@ class PostDetailAdapter(
     inner class CommentWriteViewHolder(private val binding:ItemCommentWriteBinding):
         RecyclerView.ViewHolder(binding.root){
         fun bind(){
-            val profile = profileUrl?.takeIf { it.isNotBlank() && it != "null" }?.let {
-                BuildConfig.BASE_URL.removeSuffix("/") + it
-            }
+            val profile = profileUrl?.takeIf { it.isNotBlank() && it != "null" }
             Timber.e("ic_profile: $profile")
 
             binding.ivProfile.post {
@@ -107,7 +106,6 @@ class PostDetailAdapter(
                 )
             }
 
-
            clickWrite()
         }
 
@@ -126,7 +124,7 @@ class PostDetailAdapter(
         RecyclerView.ViewHolder(binding.root) {
         fun bind(comment: ResponsePostDetailDto.CommentDto){
             with(binding){
-                val profile = comment.commenterProfileImage?.let { BuildConfig.BASE_URL.removeSuffix("/") + it }
+                val profile = comment.commenterProfileImage
 
                 ivProfile.load(profile) {
                     transformations(CircleCropTransformation())
@@ -135,6 +133,8 @@ class PostDetailAdapter(
                 }
                 tvId.text=comment.commenterName
                 tvContent.text=comment.content
+                val timeAgo = TimeAgoFormatter.formatTimeAgo(comment.createdAt)
+                tvTime.text=root.context.getString(R.string.community_time, timeAgo)
                 //tvLikeCount.text="1"
             }
 

--- a/app/src/main/java/com/data/app/presentation/main/my/MyAdapter.kt
+++ b/app/src/main/java/com/data/app/presentation/main/my/MyAdapter.kt
@@ -63,8 +63,7 @@ class MyAdapter(
 
                 if (!data.imageUrl.isNullOrEmpty()) {
                     ivImage.visibility = View.VISIBLE
-                    val imageUrl =
-                        BuildConfig.BASE_URL.removeSuffix("/") + data.imageUrl
+                    val imageUrl = data.imageUrl
                     ivImage.load(imageUrl) {
                         transformations(RoundedCornersTransformation(30f))
                     }

--- a/app/src/main/java/com/data/app/presentation/main/my/MyFragment.kt
+++ b/app/src/main/java/com/data/app/presentation/main/my/MyFragment.kt
@@ -123,7 +123,7 @@ class MyFragment : Fragment(), OnTabReselectedListener {
                         mainViewModel.saveUserId(myProfileState.response.userId)
                         with(binding) {
                             val profile =
-                                myProfileState.response.profileImage?.let { BuildConfig.BASE_URL.removeSuffix("/") + it }
+                                myProfileState.response.profileImage
                             // val resourceId = resources.getIdentifier("ic_profile", "drawable", requireContext().packageName)
                             ivProfile.load(profile) {
                                 transformations(CircleCropTransformation())
@@ -400,6 +400,7 @@ class MyFragment : Fragment(), OnTabReselectedListener {
                 }
 
                 myViewModel.editProfile(appPreferences.getAccessToken()!!, createImagePart(it))
+                myViewModel.getMyPosts(appPreferences.getAccessToken()!!)
             }
         } else if (requestCode == UCrop.REQUEST_CROP && resultCode == UCrop.RESULT_ERROR) {
             val error = UCrop.getError(data!!)

--- a/app/src/main/res/layout/item_comment.xml
+++ b/app/src/main/res/layout/item_comment.xml
@@ -30,6 +30,15 @@
         app:layout_constraintStart_toEndOf="@id/iv_profile"/>
 
     <TextView
+        android:id="@+id/tv_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        app:layout_constraintTop_toTopOf="@id/tv_id"
+        app:layout_constraintBottom_toBottomOf="@id/tv_id"
+        app:layout_constraintStart_toEndOf="@id/tv_id"/>
+
+    <TextView
         android:id="@+id/tv_content"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_post.xml
+++ b/app/src/main/res/layout/item_post.xml
@@ -50,8 +50,7 @@
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintWidth_percent="0.06"
         app:layout_constraintTop_toTopOf="@id/iv_profile"
-        app:layout_constraintBottom_toBottomOf="@id/iv_profile"
-        app:layout_constraintEnd_toEndOf="@id/btn_share"/>
+        app:layout_constraintBottom_toBottomOf="@id/iv_profile"/>
 
     <!--<androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_follow"


### PR DESCRIPTION
- 기존의 이미지 링크는 ip주소 없이 위치만 있었기에 baseurl을 추가해줬음.
- 변경된 이미지 링크는 ip주소에 위치까지 있기 때문에 바로 해당 링크로 이미지를 보여주도록 수정
- 게시물 상세보기 페이지의 createdat이 소수점 5자리까지 보이는데 기존에는 6자리까지로 해당 형식만 변환 가능했으나 변경된 형식도 변환 가능하도록 수정