### PR TITLE
fix/ex-close-chat #138

### DIFF
--- a/app/src/main/java/com/data/app/data/response_dto/home/ai/ResponseAIPreviousRecordsDto.kt
+++ b/app/src/main/java/com/data/app/data/response_dto/home/ai/ResponseAIPreviousRecordsDto.kt
@@ -20,5 +20,6 @@ data class ResponseAIPreviousRecordsDto (
         val isFinished:Boolean,
         @SerialName("description")
         val description:String,
+        var isExpanded:Boolean = false              // 클라이언트 전용 ui 상태
     )
 }

--- a/app/src/main/java/com/data/app/presentation/login/LandingActivity.kt
+++ b/app/src/main/java/com/data/app/presentation/login/LandingActivity.kt
@@ -38,13 +38,6 @@ class LandingActivity:AppCompatActivity() {
 
 
         observeLoginStateAndNavigate()
-        /*Handler(Looper.getMainLooper()).postDelayed({
-            val intent = Intent(this, LoginActivity::class.java)
-            startActivity(intent)
-            overridePendingTransition(android.R.anim.fade_in,android.R.anim.fade_out)
-        }, 2000)*/
-
-
     }
 
     private fun observeLoginStateAndNavigate() {

--- a/app/src/main/java/com/data/app/presentation/login/SignupActivity.kt
+++ b/app/src/main/java/com/data/app/presentation/login/SignupActivity.kt
@@ -137,6 +137,7 @@ class SignupActivity : AppCompatActivity() {
         }
 
         btn_signup.setOnClickListener {
+            val email = et_email.text.toString()
             val name = et_name.text.toString()
             val pw = et_pw.text.toString()
             val nationId = signUpViewModel.nationality // 이미 setOnItemClickListener에서 선택된 코드
@@ -144,6 +145,9 @@ class SignupActivity : AppCompatActivity() {
             if (nationId==0) {
                 // 예외 처리: 나라 선택 안 한 경우
                 Toast.makeText(this, "국가를 선택해주세요.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }else if(email!=signUpViewModel.email){
+                Toast.makeText(this, "이메일을 다시 확인해주세요.", Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
 
@@ -293,6 +297,11 @@ class SignupActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    private fun setLanguage(){
+        val selectedCountry = signUpViewModel.nationality
+
     }
 
     private fun isValidEmail(email: String): Boolean {

--- a/app/src/main/java/com/data/app/presentation/login/SignupViewmodel.kt
+++ b/app/src/main/java/com/data/app/presentation/login/SignupViewmodel.kt
@@ -32,7 +32,7 @@ class SignupViewmodel @Inject constructor(
     val registerState:StateFlow<RegisterState> = _registerState.asStateFlow()
     val nationState: StateFlow<NationState> = _nationState.asStateFlow()
 
-    private lateinit var email:String
+    lateinit var email:String
     lateinit var username: String
     var nationality: Int = 0
     lateinit var password: String

--- a/app/src/main/res/layout/activity_previous_practice.xml
+++ b/app/src/main/res/layout/activity_previous_practice.xml
@@ -94,7 +94,6 @@
             android:layout_marginTop="15dp"
             android:nestedScrollingEnabled="false"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/cl_search_bar"
             app:layout_constraintStart_toStartOf="@id/cl_search_bar"
             app:layout_constraintTop_toBottomOf="@id/cl_search_bar"


### PR DESCRIPTION
- 기존에는 연습기록에서 아이템 터치 시 대화가 보이지만 btnArrow가 false상태였기 때문에 다시 터치하면 대화가 그대로 보이고 그제서야 btnArrow가 true로 변함
- 그리고 다시 터치하면 btnArrow는 false가 되고 대화도 사라짐
- 이 문제는 좋아요 오류때처럼 각 viewholder의 상태를 저장하지 않았던 것 그리고 isExpanding일때도 messagelist가 null이 아닐 때도 content가 아래로 슬라이드하여 보이도록 한 것, 이 두 가지 때문에 발생하는 것이었음
- 그래서 dto에 클라이언트에서만 사용할 isExpanded 변수를 추가하여 아이템을 터치하면 해당 값을 바꾸어 업데이트 되도록 함
- 그리고 messagelist에 따라서 chatcontent의 visibility가 바뀌는게 아니라 isExpanded에 따라서만 바뀌도록 수정함
----
- 이전 연습 기록에서 아이템이 하나일 때 세로 정렬되는 현상이 있었음
- bottomToBottom=parent를 삭제하여 위에서부터 정렬되도록 수정함