### PR TITLE
fix/post-detail

### DIFF
--- a/app/src/main/java/com/data/app/presentation/main/community/post_detail/PostDetailFragment.kt
+++ b/app/src/main/java/com/data/app/presentation/main/community/post_detail/PostDetailFragment.kt
@@ -53,7 +53,9 @@ class PostDetailFragment : Fragment() {
     private val postDetailViewModel: PostDetailViewModel by viewModels()
     private val mainViewModel: MainViewModel by activityViewModels()
     private lateinit var postDetailAdapter: PostDetailAdapter
-    private var isFirstLoading=false
+    private var isFirstLoading = false
+    private var isFromCommentWrite = false
+
 
     @Inject
     lateinit var appPreferences: AppPreferences
@@ -111,12 +113,12 @@ class PostDetailFragment : Fragment() {
                         val post = postState.response
 
                         //binding.btnFollow.isSelected = post.isFollowing
-                        if(isFirstLoading){
+                        if(isFromCommentWrite){
                             binding.tvCommentCount.text = post.commentCount.toString()
+                            isFromCommentWrite = false
                         } else{
                             showPost(post)
                             showImages(post)
-                            isFirstLoading=true
                         }
 
                         getUserProfile(postState.response.comments)
@@ -365,6 +367,7 @@ class PostDetailFragment : Fragment() {
     }
 
     private fun writeComment(postId: Int, content: String) {
+        isFromCommentWrite = true
         postDetailViewModel.writeComment(appPreferences.getAccessToken()!!, postId, content)
     }
 


### PR DESCRIPTION
- 포스트 상세보기 페이지에서 타 사용자 프로필 페이지로 넘어간 후 뒤로가기하여 다시 포스트 상세보기로 넘어왔을 때 내용이 하드코딩 된 내용이었음
- 댓글 작성했을 때 isFromcomment 변수를 true로 두고 업데이트가 되면 다시 false로 두어 포스트 상세보기가 다시 보여질 때 내용이 변경되지 않도록 수정함