### PR TITLE
fix/profile-edit

### DIFF
--- a/app/src/main/java/com/data/app/presentation/main/my/MyFragment.kt
+++ b/app/src/main/java/com/data/app/presentation/main/my/MyFragment.kt
@@ -529,13 +529,13 @@ class MyFragment : Fragment(), OnTabReselectedListener {
 
     fun dataUpdate() {
         Timber.d("🌀 MyFragment refresh() 호출")
-        myViewModel.getMyPosts(appPreferences.getAccessToken()!!)
         myViewModel.getProfile(appPreferences.getAccessToken()!!)
+       // myViewModel.getMyPosts(appPreferences.getAccessToken()!!)
     }
 
     override fun onTabReselected() {
-        myViewModel.getMyPosts(appPreferences.getAccessToken()!!)
         myViewModel.getProfile(appPreferences.getAccessToken()!!)
+       // myViewModel.getMyPosts(appPreferences.getAccessToken()!!)
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
- 프로필 수정 후 내 게시물의 프로필은 수정되지 않은 오류 발견
- 프로필 수정 후 mypost, myprofile 순으로 get 하는데 myprofile 함수 안에서 mypost를 가져오기 때문에 myprofile만 남김